### PR TITLE
add autoresponder_from param when turning autoresponder on

### DIFF
--- a/webfaction/endpoint.rb
+++ b/webfaction/endpoint.rb
@@ -30,7 +30,8 @@ module WebFaction
         @username,
         true,
         args["subject"] || "",
-        args["body"] || "")  
+        args["body"] || "",
+        @email)
     end
 
 


### PR DESCRIPTION
The webfaction docs say autoresponder_from is optional
http://docs.webfaction.com/xmlrpc-api/apiref.html#mailboxes
but when an empty string is passed for that param in update_email
the autoresponder functionality does not seem to work.

This uses the email address the user logged in with instead of adding
an email address field.
